### PR TITLE
Enable Box component gap prop to use css values

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -586,14 +586,14 @@ const gapStyle = (directionProp, gap, responsive, theme) => {
   if (directionProp === 'column') {
     styles.push(
       css`
-        height: ${theme.global.edgeSize[gap]};
+        height: ${theme.global.edgeSize[gap] || gap};
       `,
     );
     if (responsiveSize) {
       styles.push(breakpointStyle(breakpoint, `height: ${responsiveSize};`));
     }
   } else {
-    styles.push(`width: ${theme.global.edgeSize[gap]};`);
+    styles.push(`width: ${theme.global.edgeSize[gap] || gap};`);
     if (responsive && directionProp === 'row-responsive') {
       styles.push(
         breakpointStyle(

--- a/src/js/components/Box/__tests__/Box-test.js
+++ b/src/js/components/Box/__tests__/Box-test.js
@@ -218,7 +218,7 @@ describe('Box', () => {
   test('gap', () => {
     const component = renderer.create(
       <Grommet>
-        {['xsmall', 'small', 'medium', 'large'].map(gap => (
+        {['xsmall', 'small', 'medium', 'large', '80px'].map(gap => (
           <Box key={gap} gap={gap} direction="row">
             <Box />
           </Box>

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.js.snap
@@ -3628,6 +3628,13 @@ exports[`Box gap 1`] = `
       className="c2"
     />
   </div>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    />
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
#### What does this PR do?

Enables the box gap prop to support just a css value as well

#### Where should the reviewer start?

Box component

#### What testing has been done on this PR?

None

#### How should this be manually tested?

Adding in gap with a pixel / css value

#### Any background context you want to provide?

Fixing a discrepancy with the docs

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Nope.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible :) 
